### PR TITLE
Publish to NPM

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
 
-      - uses: actions/cache@v4
+      - name: Retrieve Bun cache
+        uses: actions/cache@v4
         with:
           path: |
             ~/.bun/install/cache
@@ -34,9 +35,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
 
-      - uses: actions/cache@v4
+      - name: Retrieve Bun cache
+        uses: actions/cache@v4
         with:
           path: |
             ~/.bun/install/cache
@@ -56,9 +58,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
 
-      - uses: actions/cache@v4
+      - name: Retrieve Bun cache
+        uses: actions/cache@v4
         with:
           path: |
             ~/.bun/install/cache
@@ -78,9 +81,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
 
-      - uses: actions/cache@v4
+      - name: Retrieve Bun cache
+        uses: actions/cache@v4
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 'latest' # or "latest", "canary", <sha>
+
+      - name: Install dependencies
+        run: bun i
+
+      - name: Build project
+        run: bun run build
+
+      - name: Publish to npm
+        run: bun publish
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,7 @@
 name: Publish Package
+permissions:
+  contents: read
+  packages: write
 
 on:
   workflow_dispatch:
@@ -7,25 +10,26 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out
+        uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 'latest' # or "latest", "canary", <sha>
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
-      - name: get package version
+      - name: Get package version
         id: package-version
         run: |
           VERSION=$(jq -r '.version' package.json)
-          echo "version=$VERSION" >> "$github_output"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           if [[ "$VERSION" =~ ^0\. ]]; then
-            echo "is_prerelease=true" >> "$github_output"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_prerelease=false" >> "$github_output"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/cache@v4
+      - name: Retrieve Bun cache
+        uses: actions/cache@v4
         with:
           path: |
             ~/.bun/install/cache
@@ -42,8 +46,8 @@ jobs:
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: create release
-        uses: softprops/action-gh-release@v1
+      - name: Create release
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.package-version.outputs.version }}
           name: local-first ${{ steps.package-version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,24 @@ jobs:
         with:
           bun-version: 'latest' # or "latest", "canary", <sha>
 
+      - name: get package version
+        id: package-version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> "$github_output"
+
+          if [[ "$VERSION" =~ ^0\. ]]; then
+            echo "is_prerelease=true" >> "$github_output"
+          else
+            echo "is_prerelease=false" >> "$github_output"
+          fi
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+
       - name: Install dependencies
         run: bun i
 
@@ -23,3 +41,12 @@ jobs:
         run: bun publish
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.package-version.outputs.version }}
+          name: local-first ${{ steps.package-version.outputs.version }}
+          prerelease: ${{ steps.package-version.outputs.is_prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.js",
   "type": "module",
   "version": "0.0.1",
-  "private": true,
+  "private": false,
   "sideEffects": false,
   "devDependencies": {
     "@eslint/compat": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "local-first",
   "module": "./dist/index.js",
   "type": "module",
+  "version": "0.0.1",
   "private": true,
   "sideEffects": false,
   "devDependencies": {


### PR DESCRIPTION
Adds a GitHub Action that (should) allow for publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new workflow to enable manual publishing of the package to npm via GitHub Actions.
  * Set initial package version to 0.0.1.
  * Updated workflows to use the latest Bun setup action and improved cache step naming for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->